### PR TITLE
Improvements to composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 Create React components in a way analogous to `React.createClass`, but powered by [stampit](https://github.com/ericelliott/stampit)'s composable object factories.
 
-**_This is a work in progress. The factory currently produces React components, but composition implementation is being drafted [in this PR](https://github.com/troutowicz/react-stampit/pull/2). Also check below for React issues that are pending._**
-
 ## Install
 
 react-stampit can be [installed via npm](https://www.npmjs.com/package/react-stampit)
@@ -18,93 +16,85 @@ npm install react-stampit
 
 or by [downloading the latest release](https://github.com/troutowicz/react-stampit/releases).
 
-## Features
+## What is this
 
- * Create factory functions (called stamps) which stamp out new React components. All of the new React components inherit all of the prescribed behavior.
+This library is the result of wondering about what other ways a React component could be represented. [Stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) are a cool concept, and more importantly have proven to be a great alternative to `React.createClass` and the ES6 `class` due to their flexability and use of multiple kinds of prototypal inheritance.
 
- * Compose stamps together to create new stamps. Mixins!
-
-## Use
-
-Let's start by creating the simplest of React components.
-
-```js
-const baseComponent = stampit(React, {
-  render() {
-    return this.state;
-  },
-});
-```
-
-Maybe we have a need for a reusable util function.
-
-```js
-const utils = stampit(React, {
-  statics: {
-    someUtil() {
-      return 'reusability through composability!';
-    },
-  },
-});
-```
-
-Now for our final form.
+react-stampit has an API similar to `React.createClass`. The factory accepts two parameters, the first being the React library and the second being an object comprised of React component properties.
 
 ```js
 const component = stampit(React, {
-  /**
-   * state: {},
-   * statics: {},
-   *
-   * contextTypes: {},
-   * childContextTypes: {}.
-   * propTypes: {},
-   * defaultProps: {},
-   *
-   * ...lifecycleMethods
-   */
+  state: {},
+  statics: {},
 
-   state: {
-     foo: 'foo',
-   },
-}).compose(baseComponent, utils);
+  // convenience props for React statics
+  contextTypes: {},
+  childContextTypes: {}.
+  propTypes: {},
+  defaultProps: {},
+
+  // ...methods
+});
 ```
+
+The best part about [stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) is their composability. What this means is that `n` number of stamps can be combined into a new stamp which inherits each passed stamp's behavior. This is perfect for React, since `class` is being pushed as the new norm and does not provide an idiomatic way to use mixins. (classical inheritance :/). Stamp composability is 100% idiomatic and provides a limitless way to extend any React component.
 
 ```js
-test('component().render()', (t) => {
-  t.plan(1);
-
-  t.equal(
-    component().render().foo,
-    'foo',
-    'should be inherited from `baseComponent`'
-  );
+const mixin1 = stampit(null, {
+  componentDidMount() {
+    this.state.mixin1 = true;
+  },
 });
 
->> ok
-
-test('component.someUtil()', (t) => {
-  t.plan(1);
-
-  t.equal(
-    component.someUtil(),
-    'reusability through composability!',
-    'should be inherited from `utils`'
-  );
+const mixin2 = stampit(null, {
+  componentDidMount() {
+    this.state.mixin2 = true;
+  },
 });
+
+const component = stampit(React, {
+  state: {
+    comp: false,
+    mixin1: false,
+    mixin2: false,
+  },
+
+  someMethod() {
+    this.state.comp = true;
+  },
+
+  componentDidMount() {
+    this.someMethod();
+  },
+}).compose(mixin1, mixin2);
+
+const instance = component();
+instance.componentDidMount();
+
+assert.deepEqual(
+  instance.state,
+  { comp: true, mixin1: true, mixin2: true }
+);
 
 >> ok
 ```
+
+You may have noticed a couple of interesting behaviors.
+
+First, `this` just works. This is not `React.createClass` magical autobinding. Stamps are regular objects, and behave like it. Secondly, no `call super`?! react-stampit will wrap React methods during composition, providing functional inheritance. Sweet.
+
+If you feel limited by `class`, or want a fresh take on `React.createClass`, maybe give react-stampit a try and learn more about what [stampit](https://github.com/ericelliott/stampit) is all about. And please report any issues you encounter!
 
 ## API
 
-### stampit(React, [properties])
+### stampit(React [,properties])
 
 Return a factory function (called a stamp) that will produce new React components using the prototypes that are passed in or composed.
 
-* `@param {Object} React` The React module.
+* `@param {Object} React` The React library.
 * `@param {Object} [props]` A map of property names and values specialized for React.
 * `@return {Function} stamp` A factory to produce React components using the given properties.
+* `@return {Object} stamp.fixed` An object map containing the fixed prototypes.
 * `@return {Function} stamp.compose` Add mixin (stamp) to stamp. Chainable.
 
 ## The stamp object
@@ -130,8 +120,8 @@ properties with last-in priority.
 * `@return {Function}` A new stamp composed from arguments.
 
 ## Issues
-* [childContextTypes](https://github.com/facebook/react/pull/3940)
-* [component testing](https://github.com/facebook/react/pull/3941)
+* ~~[childContextTypes](https://github.com/facebook/react/pull/3940)~~
+* ~~[component testing](https://github.com/facebook/react/pull/3941)~~
 
 ## License
 [![MIT](https://img.shields.io/badge/license-MIT-blue.svg)](http://troutowicz.mit-license.org)

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "dist/"
   ],
   "scripts": {
-    "build": "npm run clean && babel src --out-dir dist --stage 1",
+    "build": "npm run clean && babel src --out-dir dist",
     "clean": "rimraf dist",
     "lint": "eslint src test",
     "prepublish": "npm run test && npm run build",
-    "test": "npm run lint && babel-node --stage 1 node_modules/.bin/tape test/basics.js test/props.js test/compose.js"
+    "test": "npm run lint && babel-node test/test.js"
   },
   "repository": {
     "type": "git",
@@ -29,13 +29,15 @@
   },
   "homepage": "https://github.com/troutowicz/react-stampit",
   "dependencies": {
-    "stampit": "^1.1.0"
+    "lodash": "^3.9.3",
+    "stampit": "^1.2.0"
   },
   "devDependencies": {
     "babel": "^5.4.7",
-    "babel-eslint": "^3.1.8",
-    "eslint": "^0.21.2",
+    "babel-eslint": "^3.1.9",
+    "eslint": "^0.22.1",
     "react": "^0.13.3",
+    "rewire": "^2.3.3",
     "rimraf": "^2.3.4",
     "tape": "^4.0.0"
   }

--- a/src/stampit.js
+++ b/src/stampit.js
@@ -1,94 +1,203 @@
+import assign from 'lodash/object/assign';
+import forEach from 'lodash/collection/forEach';
+import has from 'lodash/object/has';
+import mapValues from 'lodash/object/mapValues';
+import merge from 'lodash/object/merge';
+import omit from 'lodash/object/omit';
+import pick from 'lodash/object/pick';
 import stampit from 'stampit';
 
-const compose = function (...stamps) {
-  let statics = {};
-
-  stamps.forEach((stamp) => {
-    /* eslint-disable */
-    const {
-      create,
-      fixed,
-      compose,
-      ...other
-    } = stamp;
-    /* eslint-enable */
-
-    stampit.mixIn(statics, other);
-  });
-
-  /**
-   * Called by stamp
-   */
-  if (typeof this === 'function') {
-    return stampit.mixIn(
-      stampit.compose(this, ...stamps),
-      statics
-    );
-  }
-
-  /**
-   * Called by stampit
-   */
-  return stampit.mixIn(
-    stampit.compose(...stamps),
-    statics
-  );
-};
-
-const rStampit = function (React, props) {
-  if (!React) {
-    return undefined;
-  }
-
-  const react = stampit.convertConstructor(React.Component);
-
-  let {
-    state,
-    statics,
-    contextTypes,
-    childContextTypes,
-    propTypes,
-    defaultProps,
-    /* eslint-disable */
-    ...methods
-    /* eslint-enable */
-  } = props;
-
-  statics = statics || {};
-  if (contextTypes) {
-    statics.contextTypes = contextTypes;
-  }
-  if (childContextTypes) {
-    statics.childContextTypes = childContextTypes;
-  }
-  if (propTypes) {
-    statics.propTypes = propTypes;
-  }
-  if (defaultProps) {
-    statics.defaultProps = defaultProps;
-  }
-
-  let stamp = stampit
-    .compose(react)
-    .enclose(function () {
-      if (state) {
-        this.state = state;
-      }
-    })
-    .methods(methods);
-
-  /**
-   * Lockdown factory
-   */
+function stripStamp(stamp) {
+  delete stamp.create;
   delete stamp.methods;
   delete stamp.state;
   delete stamp.enclose;
-  stamp.compose = compose;
+  delete stamp.static;
 
-  return stampit.mixIn(stamp, statics);
+  return stamp;
+}
+
+const dupeFilter = function (prev, next, key, dest) {
+  if (dest[key]) {
+    throw new TypeError('Cannot mixin key `' + key + '` because it is provided by multiple sources.');
+  }
+
+  return next;
 };
 
-export default stampit.mixIn(rStampit, {
+/**
+ * Iterate through stamp methods, creating wrapper
+ * functions for mixable React methods,
+ * starting execution with last-in.
+ *
+ * @param {Object} dest Method destination
+ * @param {Object} src New methods
+ * @return {Object} An object of methods
+ */
+function wrapFunctions(targ, src) {
+  let funcs;
+  const mixability = {
+    componentWillMount: 'many',
+    componentDidMount: 'many',
+    componentWillReceiveProps: 'many',
+    componentWillUpdate: 'many',
+    shouldComponentUpdate: 'once',
+    componentDidUpdate: 'many',
+    render: 'once',
+    componentWillUnmount: 'many',
+    getChildContext: 'many_merged',
+  };
+
+  funcs = mapValues(src, (val, key) => {
+    if (typeof val === 'function') {
+      switch (mixability[key]) {
+        case 'many':
+          return function () {
+            const res1 = val.apply(this, arguments);
+            const res2 = targ[key] && targ[key].apply(this, arguments);
+
+            return res2 || res1;
+          };
+        case 'many_merged':
+          return function () {
+            const res1 = val.apply(this, arguments);
+            const res2 = targ[key] && targ[key].apply(this, arguments);
+
+            if (res2) {
+              return assign({}, res1, res2, dupeFilter);
+            }
+
+            return res1;
+          };
+        case 'once':
+        default:
+          if (!targ[key]) {
+            return val;
+          }
+
+          throw new TypeError('Cannot mixin `' + key + '` because it has a unique constraint.');
+      }
+    }
+  });
+
+  return assign({}, targ, funcs);
+}
+
+/**
+ * Process the static properties of a stamp and
+ * combine the result with the passed in statics object.
+ *
+ * @param {Object} stamp A stamp
+ * @param {Object} prev An object of past static properties
+ * @return {Object} A processed object of static properties
+ */
+function extractStatics(stamp, prev) {
+  let statics = assign({}, prev);
+  const filtered = omit(stamp, ['create', 'fixed', 'compose', 'static']),
+        dupeCheck = ['propTypes', 'defaultProps'];
+
+  forEach(filtered, (val, key) => {
+    if (dupeCheck.indexOf(key) >= 0) {
+      statics[key] = assign({}, statics[key], val, dupeFilter);
+    } else if (typeof val === 'object') {
+      statics[key] = assign({}, statics[key], val);
+    } else {
+      statics[key] = val;
+    }
+  });
+
+  return statics;
+}
+
+/**
+ * Take two or more stamps produced from react-stampit or
+ * stampit and combine them to produce and return a new stamp.
+ * Combining overrides properties with last-in priority.
+ *
+ * state - concatenative inheritance / cloning
+ *   - deep merge
+ *
+ * statics - concatenative inheritance / cloning
+ *   - deep merge React statics
+ *   - deep copy non-React statics
+ *
+ * methods - functional inheritance / closure prototypes
+ *   - execute wrapped methods with last-in priority
+ *
+ * @param {...Function} stamp Two or more stamps.
+ * @return {Function} A new stamp composed from arguments.
+ */
+function compose(...factories) {
+  let stamps = factories.slice(),
+      result = stampit(),
+      f = result.fixed,
+      statics = {};
+  result.compose = compose;
+  f.state = { state: {} };
+
+  if (typeof this === 'function') {
+    stamps.push(this);
+  }
+
+  forEach(stamps, stamp => {
+    statics = extractStatics(stamp, statics);
+
+    if (stamp && stamp.fixed) {
+      if (stamp.fixed.methods) {
+        f.methods = wrapFunctions(f.methods, stamp.fixed.methods);
+      }
+
+      if (stamp.fixed.state) {
+        if (stamp.fixed.state.state) {
+          f.state.state = merge({}, f.state.state, stamp.fixed.state.state, dupeFilter);
+        }
+      }
+    }
+  });
+
+  return assign(stripStamp(result), statics);
+}
+
+/**
+ * Return a factory function (called a stamp) that will produce new
+ * React components using the prototypes that are passed in or composed.
+ *
+ * @param {Object} React  The React library.
+ * @param {Object} [props]  A map of property names and values specialized for React.
+ * @return {Function} stamp A factory to produce React components using the given properties.
+ * @return {Object} stamp.fixed An object map containing the fixed prototypes.
+ */
+function rStampit(React, props) {
+  let react = {}, stamp;
+
+  if (React) {
+    react = stampit.convertConstructor(React.Component);
+  }
+  // shortcut for `convertConstructor`
+  if (!props) {
+    return react;
+  }
+
+  const filtered = omit(props, ['state', 'statics']);
+  const statics = assign({},
+    props.statics,
+    pick(filtered, ['contextTypes', 'childContextTypes', 'propTypes', 'defaultProps'])
+  );
+  const methods = omit(filtered, (val, key) => has(statics, key));
+
+  stamp = stampit
+    .compose(react)
+    .methods(methods);
+  stamp.compose = compose;
+
+  if (props.state) {
+    stamp.state({ state: props.state });
+  }
+
+  return assign(stripStamp(stamp), statics);
+}
+
+export default assign(rStampit, {
   /**
    * Utility methods to expose
    */

--- a/test/basics.js
+++ b/test/basics.js
@@ -10,10 +10,10 @@ test('stampit()', (t) => {
 
   const stamp = stampit();
 
-  t.equal(
-    typeof stamp,
-    'undefined',
-    'should return undefined'
+  t.deepEqual(
+    stamp,
+    {},
+    'should return an empty object'
   );
 });
 
@@ -21,6 +21,30 @@ test('stampit(React, props)', (t) => {
   t.plan(1);
 
   const stamp = stampit(React, {});
+
+  t.equal(
+    typeof stamp,
+    'function',
+    'should return a function'
+  );
+});
+
+test('stampit(React)', (t) => {
+  t.plan(1);
+
+  const stamp = stampit(React);
+
+  t.equal(
+    typeof stamp,
+    'function',
+    'should return a function'
+  );
+});
+
+test('stampit(null, props)', (t) => {
+  t.plan(1);
+
+  const stamp = stampit(null, {});
 
   t.equal(
     typeof stamp,
@@ -62,6 +86,16 @@ test('stampit.compose', (t) => {
   );
 });
 
+test('stampit(React, props).create', (t) => {
+  t.plan(1);
+
+  t.equal(
+    typeof stampit(React, {}).create,
+    'undefined',
+    'should be undefined'
+  );
+});
+
 test('stampit(React, props).methods', (t) => {
   t.plan(1);
 
@@ -87,6 +121,16 @@ test('stampit(React, props).enclose', (t) => {
 
   t.equal(
     typeof stampit(React, {}).enclose,
+    'undefined',
+    'should be undefined'
+  );
+});
+
+test('stampit(React, props).static', (t) => {
+  t.plan(1);
+
+  t.equal(
+    typeof stampit(React, {}).static,
     'undefined',
     'should be undefined'
   );

--- a/test/compose.js
+++ b/test/compose.js
@@ -6,18 +6,16 @@ import stampit from '../src/stampit';
 test('stampit(React, props).compose(stamp2)', (t) => {
   t.plan(1);
 
-  const stamp2 = stampit(React, {
-    render() {
+  const mixin = stampit(null, {
+    componentDidMount() {
       return 'mixin';
     },
   });
 
-  const stamp = stampit(React, {
-    render() {},
-  }).compose(stamp2);
+  const stamp = stampit(React).compose(mixin);
 
   t.equal(
-    stamp().render(),
+    stamp().componentDidMount(),
     'mixin',
     'should return a factory composed from `this` and passed args'
   );
@@ -26,13 +24,13 @@ test('stampit(React, props).compose(stamp2)', (t) => {
 test('stampit(React, props).compose(stamp2, stamp3)', (t) => {
   t.plan(2);
 
-  const baseComponent = stampit(React, {
+  const mixin1 = stampit(null, {
     render() {
       return this.state;
     },
   });
 
-  const utils = stampit(React, {
+  const mixin2 = stampit(null, {
     statics: {
       someUtil() {
         return 'reusability through composability!';
@@ -40,21 +38,20 @@ test('stampit(React, props).compose(stamp2, stamp3)', (t) => {
     },
   });
 
-  const component = stampit(React, {
+  const stamp = stampit(React, {
     state: {
       foo: 'foo',
     },
-  }).compose(baseComponent, utils);
-
+  }).compose(mixin1, mixin2);
 
   t.equal(
-    component().render().foo,
+    stamp().render().foo,
     'foo',
     'should expose `this` to inherited methods'
   );
 
   t.equal(
-    component.someUtil(),
+    stamp.someUtil(),
     'reusability through composability!',
     'should inherit static methods'
   );
@@ -63,13 +60,230 @@ test('stampit(React, props).compose(stamp2, stamp3)', (t) => {
 test('stampit.compose(stamp1, stamp2)', (t) => {
   t.plan(1);
 
-  const stamp1 = stampit(React, {});
-  const stamp2 = stampit(React, {
-    render() {},
+  const mixin = stampit(null, {
+    render() {
+      return this.state;
+    },
+  });
+  const stamp = stampit(React, {
+    state: {
+      foo: 'foo',
+    },
   });
 
-  t.ok(
-    stampit.compose(stamp1, stamp2)().render,
+  t.equal(
+    stampit.compose(stamp, mixin)().render().foo,
+    'foo',
     'should return a factory composed from args'
   );
 });
+
+test('stamps composed of stamps with state', (t) => {
+  t.plan(1);
+
+  const mixin = stampit(null, {
+    state: {
+      foo: 'foo',
+      bar: 'bar',
+    },
+  });
+
+  const stamp = stampit(React, {})
+    .compose(mixin);
+
+  t.ok(
+     stamp().state.foo && stamp().state.bar,
+    'should inherit state overriding with last-in priority'
+  );
+});
+
+test('stamps composed of stamps with React statics', (t) => {
+  t.plan(6);
+
+  const mixin = stampit(null, {
+    contextTypes: {
+      foo: React.PropTypes.string,
+    },
+    childContextTypes: {
+      foo: React.PropTypes.string,
+    },
+    propTypes: {
+      foo: React.PropTypes.string,
+    },
+    defaultProps: {
+      foo: 'foo',
+    },
+  });
+
+  const stamp = stampit(React, {
+    contextTypes: {
+      bar: React.PropTypes.string,
+    },
+    childContextTypes: {
+      bar: React.PropTypes.string,
+    },
+    propTypes: {
+      bar: React.PropTypes.string,
+    },
+    defaultProps: {
+      bar: 'bar',
+    },
+  }).compose(mixin);
+
+  const failStamp1 = stampit(React, {
+    propTypes: {
+      foo: React.PropTypes.string,
+    },
+  });
+
+  const failStamp2 = stampit(React, {
+    defaultProps: {
+      foo: 'foo',
+    },
+  });
+
+  t.ok(
+    stamp.contextTypes.foo && stamp.contextTypes.bar,
+    'should inherit `contextTypes` props'
+  );
+
+  t.ok(
+    stamp.childContextTypes.foo && stamp.childContextTypes.bar,
+    'should inherit `childContextTypes` props'
+  );
+
+  t.ok(
+    stamp.propTypes.foo && stamp.propTypes.bar,
+    'should inherit `propTypes` props'
+  );
+
+  t.ok(
+    stamp.defaultProps.foo && stamp.defaultProps.bar,
+    'should inherit `defaultProps` props'
+  );
+
+  t.throws(
+    () => failStamp1.compose(mixin),
+    TypeError,
+    'should throw on duplicate keys in `propTypes`'
+  );
+
+  t.throws(
+    () => failStamp2.compose(mixin),
+    TypeError,
+    'should throw on duplicate keys in `defaultProps`'
+  );
+});
+
+test('stamps composed of stamps with non-React statics', (t) => {
+  t.plan(2);
+
+  const mixin = stampit(null, {
+    statics: {
+      someObj: {
+        foo: 'foo',
+        bar: ' ',
+      },
+      someFunc() {
+        return 'foo';
+      },
+    },
+  });
+
+  const stamp = stampit(React, {
+    statics: {
+      someObj: {
+        bar: 'bar',
+      },
+      someFunc() {
+        return 'bar';
+      },
+    },
+  }).compose(mixin);
+
+  t.deepEqual(
+    stamp.someObj,
+    { foo: 'foo', bar: 'bar' },
+    'should inherit static objects overriding props with last-in priority'
+  );
+
+  t.equal(
+    stamp.someFunc(),
+    'bar',
+    'should inherit static methods overriding with last-in priority'
+  );
+});
+
+test('stamps composed of stamps with mixable methods', (t) => {
+  t.plan(2);
+
+  const mixin1 = stampit(null, {
+    getChildContext() {
+      return {
+        foo: 'foo',
+      };
+    },
+
+    componentDidMount() {
+      this.state.mixin1 = true;
+    },
+  });
+
+  const mixin2 = stampit(null, {
+    componentDidMount() {
+      this.state.mixin2 = true;
+    },
+  });
+
+  const stamp = stampit(React, {
+    state: {
+      stamp: false,
+      mixin1: false,
+      mixin2: false,
+    },
+
+    getChildContext() {
+      return {
+        bar: 'bar',
+      };
+    },
+
+    componentDidMount() {
+      this.state.stamp = true;
+    },
+  }).compose(mixin1, mixin2);
+
+  const instance = stamp();
+  instance.componentDidMount();
+
+  t.deepEqual(
+    instance.state,
+    { stamp: true, mixin1: true, mixin2: true },
+    'should inherit functionality of mixable methods'
+  );
+
+  t.deepEqual(
+    instance.getChildContext(),
+    { foo: 'foo', bar: 'bar' },
+    'should inherit functionality of getChildContext'
+  );
+});
+
+test('stamps composed of stamps with non-mixable methods', (t) => {
+  t.plan(1);
+
+  const mixin = stampit(null, {
+    render() {},
+  });
+
+  const stamp = stampit(React, {
+    render() {},
+  });
+
+  t.throws(
+    () => stamp.compose(mixin),
+    TypeError,
+    'should throw on duplicate methods'
+  );
+});
+

--- a/test/methods.js
+++ b/test/methods.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import test from 'tape';
+
+import stampit from '../src/stampit';
+
+test('stampit(React, { func() {} })()', (t) => {
+  t.plan(1);
+
+  const stamp = stampit(React, {
+    render() {},
+  });
+
+  t.equal(
+    typeof Object.getPrototypeOf(stamp()).render,
+    'function',
+    'should return an instance with `func` as internal proto prop'
+  );
+});

--- a/test/state.js
+++ b/test/state.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import test from 'tape';
+
+import stampit from '../src/stampit';
+
+test('stampit(React, { state: obj })()', (t) => {
+  t.plan(1);
+
+  const stamp = stampit(React, {
+    state: {
+      foo: 'foo',
+    },
+
+    render() {},
+  });
+
+  t.equal(
+    stamp().state.foo,
+    'foo',
+    'should return an instance with `state` prop'
+  );
+});

--- a/test/statics.js
+++ b/test/statics.js
@@ -3,24 +3,6 @@ import test from 'tape';
 
 import stampit from '../src/stampit';
 
-test('stampit(React, { state: obj })()', (t) => {
-  t.plan(1);
-
-  const stamp = stampit(React, {
-    state: {
-      foo: 'foo',
-    },
-
-    render() {},
-  });
-
-  t.equal(
-    stamp().state.foo,
-    'foo',
-    'should return an instance with `state` prop'
-  );
-});
-
 test('stampit(React, { statics: obj })', (t) => {
   t.plan(1);
 
@@ -100,19 +82,5 @@ test('stampit(React, { defaultProps: obj })', (t) => {
     typeof stamp.defaultProps,
     'object',
     'should return a factory with `defaultProps` prop'
-  );
-});
-
-test('stampit(React, { func() {} })()', (t) => {
-  t.plan(1);
-
-  const stamp = stampit(React, {
-    render() {},
-  });
-
-  t.equal(
-    typeof Object.getPrototypeOf(stamp()).render,
-    'function',
-    'should return an instance with `func` as internal proto prop'
   );
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,6 @@
+require('./basics');
+require('./state');
+require('./statics');
+require('./methods');
+require('./compose');
+require('./wrapFunctions');

--- a/test/wrapFunctions.js
+++ b/test/wrapFunctions.js
@@ -1,0 +1,60 @@
+import rewire from 'rewire';
+import test from 'tape';
+
+let stampit = rewire('../src/stampit');
+let wrapFunctions = stampit.__get__('wrapFunctions');
+
+test('wrapFunctions(obj1, obj2)', (t) => {
+  t.plan(6);
+
+  /* eslint-disable */
+  const obj1 = {
+    componentWillMount() { return this.wrapped },
+    componentDidMount() { return this.wrapped },
+    componentWillReceiveProps() { return this.wrapped },
+    componentWillUpdate() { return this.wrapped },
+    componentDidUpdate() { return this.wrapped },
+    componentWillUnmount() { return this.wrapped },
+    //someOtherFunc() { return this.wrapped },
+  };
+
+  const obj2 = {
+    componentWillMount() { this.wrapped = true },
+    componentDidMount() { this.wrapped = true },
+    componentWillReceiveProps() { this.wrapped = true },
+    componentWillUpdate() { this.wrapped = true },
+    componentDidUpdate() { this.wrapped = true },
+    componentWillUnmount() { this.wrapped = true },
+    //someOtherFunc() { this.wrapper = true },
+  };
+  /* eslint-enable */
+
+  t.ok(
+    wrapFunctions(obj1, obj2).componentWillMount(),
+    'should wrap `componentWillMount`'
+  );
+  t.ok(
+    wrapFunctions(obj1, obj2).componentDidMount(),
+    'should wrap `componentDidMount`'
+  );
+  t.ok(
+    wrapFunctions(obj1, obj2).componentWillReceiveProps(),
+    'should wrap `componentWillReceiveProps`'
+  );
+  t.ok(
+    wrapFunctions(obj1, obj2).componentWillUpdate(),
+    'should wrap `componentWillUpdate`'
+  );
+  t.ok(
+    wrapFunctions(obj1, obj2).componentDidUpdate(),
+    'should wrap `componentDidUpdate`'
+  );
+  t.ok(
+    wrapFunctions(obj1, obj2).componentWillUnmount(),
+    'should wrap `componentWillUnmount`'
+  );
+/*  t.notOk(
+    wrapFunctions(obj1, obj2).someOtherFunc(),
+    'should not wrap `someOtherFunc`'
+  );*/
+});


### PR DESCRIPTION
Just a draft on what I think the functionality could be like for React component composition. Please critique!
### State

React components should inherit other component's state, throwing on duplicate keys.
- concatenative inheritance / cloning.

``` js
const mixin = stampit(null, {
  state: {
    foo: 'foo',
    bar: 'bar',
  },
});

const component = stampit(React)
  .compose(mixin);
```

``` js
assert.deepEqual(component().state, { foo: 'foo', bar: 'bar })
  >> ok
```

`React.createClass` throws an Invariant Violation when duplicate keys are found within mixins. `react-stampit` will throw a TypeError.
### Statics

React components should inherit other component's statics, throwing on duplicate keys for `propTypes` and `defaultProps`.
- concatenative inheritance / cloning

``` js
const mixin = stampit(null, {
  statics: {
    someStatic: {
      bar: 'bar',
    },
  },

  propTypes: {
    bar: React.PropTypes.string,
  },
});

const component = stampit(React, {
  statics: {
    someStatic: {
      foo: 'foo',
    },
  },

  propTypes: {
    foo: React.PropTypes.string,
  },
}).compose(mixin);
```

``` js
assert.ok(component.propTypes.bar)
  >> ok
assert.ok(component.propTypes.foo)
  >> ok
assert.deepEqual(component.someStatic, { foo: 'foo', bar: 'bar })
  >> ok
```

`React.createClass` throws an Invariant Violation when duplicate keys are found in `getDefaultProps` and `getInitialState`. `react-stampit` will throw a TypeError.
### Methods

React components should inherit the functionality of the following lifecycle methods from other components/mixins starting execution with last-in. Any non-React methods will throw a TypeError on duplicates.
- componentWillMount
- componentDidMount
- componentWillReceiveProps
- componentWillUpdate
- componentDidUpdate
- componentWillUnmount
## 
- differential inheritance

``` js
const mixin = stampit(null, {
  componentDidMount() {
    this.state.mixin = true;
  },
});

const component = stampit(React, {
  state: {
    component: false,
    mixin: false,
  },

  componentDidMount() {
    this.state.component = true;
  }
}).compose(mixin);

const instance = component();
instance.componentDidMount();
```

``` js
assert.deepEqual(instance.state, { component: true, mixin: true });
  >> ok
```

`React.createClass` throws an Invariant Violation when duplicate `shouldComponentUpdate` or `render` methods exist, `react-stampit` will throw a TypeError.
