### PR TITLE
Fixes

### DIFF
--- a/test/basics.js
+++ b/test/basics.js
@@ -8,11 +8,8 @@ const TestUtils = React.addons.TestUtils;
 test('stampit()', (t) => {
   t.plan(1);
 
-  const stamp = stampit();
-
   t.deepEqual(
-    stamp,
-    {},
+    stampit(), {},
     'should return an empty object'
   );
 });
@@ -23,8 +20,7 @@ test('stampit(React, props)', (t) => {
   const stamp = stampit(React, {});
 
   t.equal(
-    typeof stamp,
-    'function',
+    typeof stamp, 'function',
     'should return a function'
   );
 });
@@ -35,8 +31,7 @@ test('stampit(React)', (t) => {
   const stamp = stampit(React);
 
   t.equal(
-    typeof stamp,
-    'function',
+    typeof stamp, 'function',
     'should return a function'
   );
 });
@@ -47,8 +42,7 @@ test('stampit(null, props)', (t) => {
   const stamp = stampit(null, {});
 
   t.equal(
-    typeof stamp,
-    'function',
+    typeof stamp, 'function',
     'should return a function'
   );
 });
@@ -70,8 +64,7 @@ test('stampit(React, props).compose', (t) => {
   t.plan(1);
 
   t.equal(
-    typeof stampit(React, {}).compose,
-    'function',
+    typeof stampit(React).compose, 'function',
     'should be a function'
   );
 });
@@ -80,8 +73,7 @@ test('stampit.compose', (t) => {
   t.plan(1);
 
   t.equal(
-    typeof stampit.compose,
-    'function',
+    typeof stampit.compose, 'function',
     'should be a function'
   );
 });
@@ -90,8 +82,7 @@ test('stampit(React, props).create', (t) => {
   t.plan(1);
 
   t.equal(
-    typeof stampit(React, {}).create,
-    'undefined',
+    typeof stampit(React).create, 'undefined',
     'should be undefined'
   );
 });
@@ -100,8 +91,7 @@ test('stampit(React, props).methods', (t) => {
   t.plan(1);
 
   t.equal(
-    typeof stampit(React, {}).methods,
-    'undefined',
+    typeof stampit(React).methods, 'undefined',
     'should be undefined'
   );
 });
@@ -110,8 +100,7 @@ test('stampit(React, props).state', (t) => {
   t.plan(1);
 
   t.equal(
-    typeof stampit(React, {}).state,
-    'undefined',
+    typeof stampit(React).state, 'undefined',
     'should be undefined'
   );
 });
@@ -120,8 +109,7 @@ test('stampit(React, props).enclose', (t) => {
   t.plan(1);
 
   t.equal(
-    typeof stampit(React, {}).enclose,
-    'undefined',
+    typeof stampit(React).enclose, 'undefined',
     'should be undefined'
   );
 });
@@ -130,8 +118,7 @@ test('stampit(React, props).static', (t) => {
   t.plan(1);
 
   t.equal(
-    typeof stampit(React, {}).static,
-    'undefined',
+    typeof stampit(React).static, 'undefined',
     'should be undefined'
   );
 });

--- a/test/methods.js
+++ b/test/methods.js
@@ -3,7 +3,7 @@ import test from 'tape';
 
 import stampit from '../src/stampit';
 
-test('stampit(React, { func() {} })()', (t) => {
+test('stampit(React, { method() {} })()', (t) => {
   t.plan(1);
 
   const stamp = stampit(React, {
@@ -11,8 +11,7 @@ test('stampit(React, { func() {} })()', (t) => {
   });
 
   t.equal(
-    typeof Object.getPrototypeOf(stamp()).render,
-    'function',
-    'should return an instance with `func` as internal proto prop'
+    typeof Object.getPrototypeOf(stamp()).render, 'function',
+    'should return an instance with `method` as internal proto prop'
   );
 });

--- a/test/state.js
+++ b/test/state.js
@@ -1,3 +1,4 @@
+import has from 'lodash/object/has';
 import React from 'react';
 import test from 'tape';
 
@@ -8,15 +9,12 @@ test('stampit(React, { state: obj })()', (t) => {
 
   const stamp = stampit(React, {
     state: {
-      foo: 'foo',
+      foo: '',
     },
-
-    render() {},
   });
 
-  t.equal(
-    stamp().state.foo,
-    'foo',
+  t.ok(
+    has(stamp().state, 'foo'),
     'should return an instance with `state` prop'
   );
 });

--- a/test/statics.js
+++ b/test/statics.js
@@ -1,3 +1,4 @@
+import has from 'lodash/object/has';
 import React from 'react';
 import test from 'tape';
 
@@ -8,16 +9,13 @@ test('stampit(React, { statics: obj })', (t) => {
 
   const stamp = stampit(React, {
     statics: {
-      foo: 'foo',
+      foo: '',
     },
-
-    render() {},
   });
 
-  t.equal(
-    stamp.foo,
-    'foo',
-    'should return a factory with `statics` props as props'
+  t.ok(
+    has(stamp, 'foo'),
+    'should return a stamp with `statics` props as props'
   );
 });
 
@@ -26,14 +24,11 @@ test('stampit(React, { contextTypes: obj })', (t) => {
 
   const stamp = stampit(React, {
     contextTypes: {},
-
-    render() {},
   });
 
-  t.equal(
-    typeof stamp.contextTypes,
-    'object',
-    'should return a factory with `contextTypes` prop'
+  t.ok(
+    has(stamp, 'contextTypes'),
+    'should return a stamp with `contextTypes` prop'
   );
 });
 
@@ -42,14 +37,11 @@ test('stampit(React, { childContextTypes: obj })', (t) => {
 
   const stamp = stampit(React, {
     childContextTypes: {},
-
-    render() {},
   });
 
-  t.equal(
-    typeof stamp.childContextTypes,
-    'object',
-    'should return a factory with `childContextTypes` prop'
+  t.ok(
+    has(stamp, 'childContextTypes'),
+    'should return a stamp with `childContextTypes` prop'
   );
 });
 
@@ -58,14 +50,11 @@ test('stampit(React, { propTypes: obj })', (t) => {
 
   const stamp = stampit(React, {
     propTypes: {},
-
-    render() {},
   });
 
-  t.equal(
-    typeof stamp.propTypes,
-    'object',
-    'should return a factory with `propTypes` prop'
+  t.ok(
+    has(stamp, 'propTypes'),
+    'should return a stamp with `propTypes` prop'
   );
 });
 
@@ -74,13 +63,10 @@ test('stampit(React, { defaultProps: obj })', (t) => {
 
   const stamp = stampit(React, {
     defaultProps: {},
-
-    render() {},
   });
 
-  t.equal(
-    typeof stamp.defaultProps,
-    'object',
-    'should return a factory with `defaultProps` prop'
+  t.ok(
+    has(stamp, 'defaultProps'),
+    'should return a stamp with `defaultProps` prop'
   );
 });

--- a/test/wrapFunctions.js
+++ b/test/wrapFunctions.js
@@ -5,27 +5,30 @@ let stampit = rewire('../src/stampit');
 let wrapFunctions = stampit.__get__('wrapFunctions');
 
 test('wrapFunctions(obj1, obj2)', (t) => {
-  t.plan(6);
+  t.plan(7);
 
   /* eslint-disable */
   const obj1 = {
-    componentWillMount() { return this.wrapped },
-    componentDidMount() { return this.wrapped },
-    componentWillReceiveProps() { return this.wrapped },
-    componentWillUpdate() { return this.wrapped },
-    componentDidUpdate() { return this.wrapped },
-    componentWillUnmount() { return this.wrapped },
-    //someOtherFunc() { return this.wrapped },
-  };
-
-  const obj2 = {
     componentWillMount() { this.wrapped = true },
     componentDidMount() { this.wrapped = true },
     componentWillReceiveProps() { this.wrapped = true },
     componentWillUpdate() { this.wrapped = true },
     componentDidUpdate() { this.wrapped = true },
     componentWillUnmount() { this.wrapped = true },
-    //someOtherFunc() { this.wrapper = true },
+    method() {},
+  };
+
+  const obj2 = {
+    componentWillMount() { return this.wrapped; },
+    componentDidMount() { return this.wrapped; },
+    componentWillReceiveProps() { return this.wrapped; },
+    componentWillUpdate() { return this.wrapped; },
+    componentDidUpdate() { return this.wrapped; },
+    componentWillUnmount() { return this.wrapped; },
+  };
+
+  const failObj = {
+    method() {},
   };
   /* eslint-enable */
 
@@ -33,28 +36,34 @@ test('wrapFunctions(obj1, obj2)', (t) => {
     wrapFunctions(obj1, obj2).componentWillMount(),
     'should wrap `componentWillMount`'
   );
+
   t.ok(
     wrapFunctions(obj1, obj2).componentDidMount(),
     'should wrap `componentDidMount`'
   );
+
   t.ok(
     wrapFunctions(obj1, obj2).componentWillReceiveProps(),
     'should wrap `componentWillReceiveProps`'
   );
+
   t.ok(
     wrapFunctions(obj1, obj2).componentWillUpdate(),
     'should wrap `componentWillUpdate`'
   );
+
   t.ok(
     wrapFunctions(obj1, obj2).componentDidUpdate(),
     'should wrap `componentDidUpdate`'
   );
+
   t.ok(
     wrapFunctions(obj1, obj2).componentWillUnmount(),
     'should wrap `componentWillUnmount`'
   );
-/*  t.notOk(
-    wrapFunctions(obj1, obj2).someOtherFunc(),
-    'should not wrap `someOtherFunc`'
-  );*/
+
+  t.throws(
+    () => wrapFunctions(obj1, failObj), TypeError,
+    'should throw on dupe non-React method'
+  );
 });


### PR DESCRIPTION
- Wrapped methods should fire with first-in priority, returning last-in result
- Composition should deep copy state, no need to merge as it throws on dupe keys
- `stampit(React, {})` is now equivalent to `stampit(React)`
