### PR TITLE
POJO mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or by [downloading the latest release](https://github.com/troutowicz/react-stamp
 
 ## What is this
 
-This library is the result of wondering about what other ways a React component could be represented. [Stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) are a cool concept, and more importantly have proven to be a great alternative to `React.createClass` and the ES6 `class` due to their flexability and use of multiple kinds of prototypal inheritance.
+This library is the result of wondering about what other ways a React component could be represented. [Stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) are a cool concept, and more importantly have proven to be a great alternative to `React.createClass` and the ES6 `class` due to their flexibility and use of multiple kinds of prototypal inheritance.
 
 react-stampit has an API similar to `React.createClass`. The factory accepts two parameters, the first being the React library and the second being an object comprised of React component properties.
 
@@ -37,20 +37,20 @@ const component = stampit(React, {
 });
 ```
 
-The best part about [stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) is their composability. What this means is that `n` number of stamps can be combined into a new stamp which inherits each passed stamp's behavior. This is perfect for React, since `class` is being pushed as the new norm and does not provide an idiomatic way to use mixins. (classical inheritance :/). Stamp composability is 100% idiomatic and provides a limitless way to extend any React component.
+The best part about [stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) is their composability. What this means is that `n` number of stamps can be combined into a new stamp which inherits each passed stamp's behavior. This is perfect for React, since `class` is being pushed as the new norm and does not provide an idiomatic way to use mixins. (classical inheritance :disappointed:). Stamp composability is 100% idiomatic and provides a limitless way to extend any React component.
 
 ```js
-const mixin1 = stampit(null, {
+const mixin1 = {
   componentDidMount() {
     this.state.mixin1 = true;
   },
-});
+};
 
-const mixin2 = stampit(null, {
+const mixin2 = {
   componentDidMount() {
     this.state.mixin2 = true;
   },
-});
+};
 
 const component = stampit(React, {
   state: {
@@ -79,9 +79,22 @@ assert.deepEqual(
 >> ok
 ```
 
-You may have noticed a couple of interesting behaviors.
+You may have noticed a few interesting behaviors.
 
-First, `this` just works. This is not `React.createClass` magical autobinding. Stamps are regular objects, and behave like it. Secondly, no `call super`?! react-stampit will wrap React methods during composition, providing functional inheritance. Sweet.
+* `this` just works
+
+ This is not `React.createClass` magical autobinding. Stamps are regular objects, and behave like it.
+* no `call super`
+
+ React methods are wrapped during composition, providing functional inheritance. Sweet.
+* mixins are POJOs
+
+ This is shorthand syntax for:
+ ```js
+ stampit(null, {
+   // stuff
+ });
+ ```
 
 If you feel limited by `class`, or want a fresh take on `React.createClass`, maybe give react-stampit a try and learn more about what [stampit](https://github.com/ericelliott/stampit) is all about. And please report any issues you encounter!
 
@@ -103,7 +116,6 @@ Return a factory function (called a stamp) that will produce new React component
 
 Take one or more stamps produced from `react-stampit` or `stampit` and
 combine them with `this` to produce and return a new stamp.
-Combining overrides properties with last-in priority.
 
 * `@param {...Function} stamp` One or more stamps.
 * `@return {Function}` A new stamp composed from `this` and arguments.
@@ -113,15 +125,14 @@ Combining overrides properties with last-in priority.
 ### stampit.compose([arg1], [arg2] [,arg3...])
 
 Take two or more stamps produced from `react-stampit` or `stampit` and
-combine them to produce and return a new stamp. Combining overrides
-properties with last-in priority.
+combine them to produce and return a new stamp.
 
 * `@param {...Function} stamp` Two or more stamps.
 * `@return {Function}` A new stamp composed from arguments.
 
-## Issues
-* ~~[childContextTypes](https://github.com/facebook/react/pull/3940)~~
-* ~~[component testing](https://github.com/facebook/react/pull/3941)~~
+## Pending Issues
+* [x] [childContextTypes](https://github.com/facebook/react/pull/3940)
+* [x] [component testing](https://github.com/facebook/react/pull/3941)
 
 ## License
 [![MIT](https://img.shields.io/badge/license-MIT-blue.svg)](http://troutowicz.mit-license.org)

--- a/src/stampit.js
+++ b/src/stampit.js
@@ -135,25 +135,17 @@ function compose(...factories) {
   }
 
   forEach(stamps, stamp => {
-    if (!stamp.fixed) {
-      /* eslint-disable */
-      stamp = rStampit(null, stamp);
-      /* eslint-enable */
+    /* eslint-disable */
+    stamp = !stamp.fixed ? rStampit(null, stamp) : stamp;
+    /* eslint-enable */
+
+    f.methods = stamp.fixed.methods && wrapFunctions(f.methods, stamp.fixed.methods);
+
+    if (stamp.fixed.state && stamp.fixed.state.state) {
+      f.state.state = assign({}, f.state.state, stamp.fixed.state.state, dupeFilter);
     }
 
-    if (stamp.fixed.methods) {
-      f.methods = wrapFunctions(f.methods, stamp.fixed.methods);
-    }
-
-    if (stamp.fixed.state) {
-      if (stamp.fixed.state.state) {
-        f.state.state = assign({}, f.state.state, stamp.fixed.state.state, dupeFilter);
-      }
-
-      if (stamp.fixed.static) {
-        statics = extractStatics(statics, stamp.fixed.static);
-      }
-    }
+    statics = stamp.fixed.static && extractStatics(statics, stamp.fixed.static);
   });
 
   return stripStamp(result.static(statics));
@@ -169,23 +161,21 @@ function compose(...factories) {
  * @return {Object} stamp.fixed An object map containing the fixed prototypes.
  */
 function rStampit(React, props) {
-  let react = {}, stamp;
+  const react = React ? stampit.convertConstructor(React.Component) : {};
+  let stamp, filtered, statics, methods;
 
-  if (React) {
-    react = stampit.convertConstructor(React.Component);
-  }
   // shortcut for `convertConstructor`
   if (!props || Object.keys(props) === 0) {
     react.compose = compose;
     return stripStamp(react);
   }
 
-  const filtered = omit(props, ['state', 'statics']);
-  const statics = assign({},
+  filtered = omit(props, ['state', 'statics']);
+  statics = assign({},
     props.statics,
     pick(filtered, ['contextTypes', 'childContextTypes', 'propTypes', 'defaultProps'])
   );
-  const methods = omit(filtered, (val, key) => has(statics, key));
+  methods = omit(filtered, (val, key) => has(statics, key));
 
   stamp = assign(stampit
     .compose(react)

--- a/src/stampit.js
+++ b/src/stampit.js
@@ -135,15 +135,19 @@ function compose(...factories) {
   }
 
   forEach(stamps, stamp => {
-    if (stamp && stamp.fixed) {
-      if (stamp.fixed.methods) {
-        f.methods = wrapFunctions(f.methods, stamp.fixed.methods);
-      }
+    if (!stamp.fixed) {
+      /* eslint-disable */
+      stamp = rStampit(null, stamp);
+      /* eslint-enable */
+    }
 
-      if (stamp.fixed.state) {
-        if (stamp.fixed.state.state) {
-          f.state.state = assign({}, f.state.state, stamp.fixed.state.state, dupeFilter);
-        }
+    if (stamp.fixed.methods) {
+      f.methods = wrapFunctions(f.methods, stamp.fixed.methods);
+    }
+
+    if (stamp.fixed.state) {
+      if (stamp.fixed.state.state) {
+        f.state.state = assign({}, f.state.state, stamp.fixed.state.state, dupeFilter);
       }
 
       if (stamp.fixed.static) {
@@ -172,6 +176,7 @@ function rStampit(React, props) {
   }
   // shortcut for `convertConstructor`
   if (!props || Object.keys(props) === 0) {
+    react.compose = compose;
     return stripStamp(react);
   }
 

--- a/test/basics.js
+++ b/test/basics.js
@@ -1,3 +1,4 @@
+import keys from 'lodash/object/keys';
 import React from 'react/addons';
 import test from 'tape';
 
@@ -8,9 +9,9 @@ const TestUtils = React.addons.TestUtils;
 test('stampit()', (t) => {
   t.plan(1);
 
-  t.deepEqual(
-    stampit(), {},
-    'should return an empty object'
+  t.ok(
+    keys(stampit(), ['compose']),
+    'should return an object with compose prop'
   );
 });
 

--- a/test/compose.js
+++ b/test/compose.js
@@ -17,7 +17,24 @@ test('stampit(React, props).compose(stamp2)', (t) => {
 
   t.equal(
     stamp().method(), 'mixin',
-    'should return a stamp composed of `this` and passed stamps'
+    'should return a stamp composed of `this` and passed stamp'
+  );
+});
+
+test('stampit(React, props).compose(pojo)', (t) => {
+  t.plan(1);
+
+  const mixin = {
+    method() {
+      return 'mixin';
+    },
+  };
+
+  const stamp = stampit(React).compose(mixin);
+
+  t.equal(
+    stamp().method(), 'mixin',
+    'should return a stamp composed of `this` and passed pojo'
   );
 });
 


### PR DESCRIPTION
Thoughts @ericelliott?

``` js
const mixin = {
  // stuff here
};
```

as a convenience to

``` js
const mixin = stampit(null, {
  // stuff here
});
```

POJO -> Stamp would be handled inside the compose method [here](https://github.com/troutowicz/react-stampit/pull/4/files#diff-d3d1780d19f75055166112db1c679b84R141).
