### PR TITLE
Stamp decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ If you feel limited by `class`, or want a fresh take on `React.createClass`, may
 
 Read more about react-stampit's composition [here](docs/composition.md).
 
+For some advanced use cases, see [here](docs/advanced.md).
+
 ## API
 
 ### stampit(React [,properties])

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,35 @@
+### Class decorator
+
+For all those nice guys/gals that like `class` and just want some mixability. It is assumed that the component directly extends React.Component, anything else should be inherited via stamp composition.
+
+```js
+@stamp
+class Component extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      foo: 'foo',
+    };
+  }
+
+  render() {}
+}
+
+Component.propTypes = {
+  foo: '',
+};
+
+const mixin = {
+  propTypes: {
+    bar: 'bar',
+  },
+};
+
+Component = Component.compose(mixin);
+
+assert.deepEqual(Component.propTypes, { foo: 'foo', bar: 'bar' });
+  >> ok
+```
+
+__*Warning: Class decorators are a proposal for ES7, they are not set in stone.*__

--- a/package.json
+++ b/package.json
@@ -7,17 +7,19 @@
     "dist/"
   ],
   "scripts": {
-    "build": "npm run clean && babel src --out-dir dist",
+    "build": "npm run clean && babel --stage 1 src --out-dir dist",
     "clean": "rimraf dist",
     "lint": "eslint src test",
     "prepublish": "npm run test && npm run build",
-    "test": "npm run lint && babel-node test/test.js"
+    "test": "npm run lint && babel-node --stage 1 test/test.js"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/stampit-org/react-stampit.git"
   },
   "keywords": [
+    "composability",
+    "mixins",
     "react",
     "stamp",
     "stampit"

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,78 @@
+import assign from 'lodash/object/assign';
+import stampit from 'stampit';
+
+import { compose } from './stampit';
+
+export function isStamp(obj) {
+  return (
+    typeof obj === 'function' &&
+    typeof obj.compose === 'function' &&
+    typeof obj.fixed === 'object'
+  );
+}
+
+export function stripStamp(stamp) {
+  delete stamp.create;
+  delete stamp.init;
+  delete stamp.methods;
+  delete stamp.state;
+  delete stamp.refs;
+  delete stamp.props;
+  delete stamp.enclose;
+  delete stamp.static;
+
+  return stamp;
+}
+
+/**
+ * Get object of non-enum properties
+ */
+export function getNonEnum(target) {
+  const props = Object.getOwnPropertyNames(target);
+  const enumOnly = Object.keys(target);
+  let obj = {};
+
+  props.forEach(function(key) {
+    var indexInEnum = enumOnly.indexOf(key);
+    if (indexInEnum === -1 && key !== 'constructor') {
+      obj[key] = target[key];
+    }
+  });
+
+  return obj;
+}
+
+/**
+ * Get object of enum properties
+ */
+export function getEnum(target) {
+  const props = Object.keys(target);
+  let obj = {};
+
+  props.forEach(function(key) {
+    obj[key] = target[key];
+  });
+
+  return obj;
+}
+
+/**
+ * ES7 decorator for converting ES6 class to stamp
+ */
+export function stamp(Class) {
+  const constructor = function() {
+    assign(this, new Class());
+  };
+  const methods = assign({},
+    Object.getPrototypeOf(Class).prototype,
+    getNonEnum(Class.prototype)
+  );
+
+  let stamp = stampit
+    .init(constructor)
+    .methods(methods)
+    .static(getEnum(Class));
+  stamp.compose = compose;
+
+  return stripStamp(stamp);
+}

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -1,0 +1,44 @@
+import keys from 'lodash/object/keys';
+import React from 'react';
+import test from 'tape';
+
+import stampit from '../src/stampit';
+import { stamp } from '../src/stampit';
+
+test('stamp decorator', (t) => {
+  t.plan(5);
+
+  @stamp
+  class Component extends React.Component {
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        foo: 'foo',
+      };
+    }
+
+    render() {}
+  }
+
+  Component.propTypes = {
+    foo: '',
+  };
+
+  const mixin = {
+    propTypes: {
+      bar: '',
+    },
+  };
+
+  t.ok(stampit.isStamp(Component), 'converts class to stamp');
+  /* eslint-disable new-cap */
+  t.ok(Component().state.foo, 'maps state');
+  t.ok(Component().render, 'maps methods');
+  t.ok(Component.propTypes, 'maps statics');
+  t.deepEqual(
+    keys(Component.compose(mixin).propTypes), ['bar', 'foo'],
+    'brings composability'
+  );
+  /* eslint-enable new-cap */
+});

--- a/test/test.js
+++ b/test/test.js
@@ -4,3 +4,4 @@ require('./statics');
 require('./methods');
 require('./compose');
 require('./wrapMethods');
+require('./advanced');


### PR DESCRIPTION
For all those nice guys/gals that like `class` and just want some mixability. It is assumed that the component directly extends React.Component, anything else should be inherited via stamp composition.

@ericelliott you will like this one as it works around the `class` bug mentioned [here](https://github.com/ericelliott/stampit/issues/75)!

``` js
@stamp
class Component extends React.Component {
  constructor(props) {
    super(props);

    this.state = {
      foo: 'foo',
    };
  }

  render() {}
}

Component.propTypes = {
  foo: '',
};

const mixin = {
  propTypes: {
    bar: 'bar',
  },
};

Component = Component.compose(mixin);

assert.deepEqual(Component.propTypes, { foo: 'foo', bar: 'bar' });
  >> ok
```

**_Warning: Class decorators are a proposal for ES7, they are not set in stone._**
