### PR TITLE
Improve examples, bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,49 +41,54 @@ The best part about [stamps](https://en.wikipedia.org/wiki/Stamp_%28object-orien
 
 ```js
 const mixin1 = {
-  componentDidMount() {
+  componentWillMount() {
     this.state.mixin1 = true;
   },
 };
 
 const mixin2 = {
-  componentDidMount() {
+  componentWillMount() {
     this.state.mixin2 = true;
   },
 };
 
-const component = stampit(React, {
+const Component = stampit(React, {
   state: {
     comp: false,
     mixin1: false,
     mixin2: false,
   },
 
-  someMethod() {
+  _onClick() {
+    return this.state;
+  },
+
+  componentWillMount() {
     this.state.comp = true;
   },
 
-  componentDidMount() {
-    this.someMethod();
+  render() {
+    return <input type='button' onClick={() => this._onClick()} />;
   },
 }).compose(mixin1, mixin2);
+```
 
-const instance = component();
-instance.componentDidMount();
+```js
+shallowRenderer.render(<Component />);
+const button = shallowRenderer.getRenderOutput();
 
 assert.deepEqual(
-  instance.state,
-  { comp: true, mixin1: true, mixin2: true }
+  button.props.onClick(), { comp: true, mixin1: true, mixin2: true },
+  'should return component state with all truthy props'
 );
-
->> ok
+  >> ok
 ```
 
 You may have noticed a few interesting behaviors.
 
-* `this` just works
+* no autobinding
 
- This is not `React.createClass` magical autobinding. Stamp instances are regular objects.
+ Event handlers require explicit binding. No magic. This can be done using `.bind` or through lexical binding with ES6 [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) as shown in the example.
 * no `call super`
 
  React methods are wrapped during composition, providing functional inheritance. Sweet.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -3,6 +3,9 @@
 For all those nice guys/gals that like `class` and just want some mixability. It is assumed that the component directly extends React.Component, anything else should be inherited via stamp composition.
 
 ```js
+import React from 'react/addons';
+import { stamp } from 'react-stampit';
+
 @stamp
 class Component extends React.Component {
   constructor(props) {
@@ -13,22 +16,38 @@ class Component extends React.Component {
     };
   }
 
-  render() {}
+  render() {
+    return null;
+  }
 }
 
-Component.propTypes = {
-  foo: '',
+Component.defaultProps = {
+  foo: 'foo',
 };
 
 const mixin = {
-  propTypes: {
+  state: {
+    bar: 'bar',
+  },
+
+  defaultProps: {
     bar: 'bar',
   },
 };
 
 Component = Component.compose(mixin);
+```
 
-assert.deepEqual(Component.propTypes, { foo: 'foo', bar: 'bar' });
+```js
+assert.deepEqual(
+  Component().state, { foo: 'foo', bar: 'bar' },
+  'should inherit mixin state'
+);
+  >> ok
+assert.deepEqual(
+  Component.defaultProps, { foo: 'foo', bar: 'bar' }
+  'should inherit `defaultProps` props'
+);
   >> ok
 ```
 

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -1,4 +1,4 @@
-Stamp composition might be compared to `React.createClass`'s mixin feature. A significant difference is that you compose a stamp without referencing the stamps being inherited from inside the stamp's declaration. 
+Stamp composition might be compared to `React.createClass`'s mixin feature. A significant difference is that you compose a stamp without referencing the stamps being inherited from inside the stamp's declaration.
 
 
 ### State
@@ -16,14 +16,17 @@ const component = stampit(React).compose(mixin);
 ```
 
 ```js
-assert.deepEqual(component().state, { foo: 'foo', bar: 'bar })
+assert.deepEqual(
+  component().state, { foo: 'foo', bar: 'bar },
+  'should inherit state'
+);
   >> ok
 ```
 
 __*`React.createClass` throws an Invariant Violation when duplicate keys are found within mixins. `react-stampit` will throw a TypeError.*__
 
 ### Statics
-Composed stamps inherit other stamps' statics. React statics are merged, throwing on duplicate keys for `propTypes` and `defaultProps`. Non-React statics are deep copied. 
+Composed stamps inherit other stamps' statics. React statics are merged, throwing on duplicate keys for `propTypes` and `defaultProps`. Non-React statics override with last-in priority.
 
 ```js
 const mixin = {
@@ -52,11 +55,20 @@ const component = stampit(React, {
 ```
 
 ```js
-assert.ok(component.propTypes.bar)
+assert.ok(
+  component.propTypes.bar,
+  'should inherit bar propType'
+);
   >> ok
-assert.ok(component.propTypes.foo)
+assert.ok(
+  component.propTypes.foo,
+  'should inherit foo propType'
+);
   >> ok
-assert.deepEqual(component.someStatic, { foo: 'foo' })
+assert.deepEqual(
+  component.someStatic, { foo: 'foo' },
+  'should override non-React statics'
+);
   >> ok
 ```
 
@@ -103,7 +115,10 @@ instance.componentDidMount();
 ```
 
 ```js
-assert.deepEqual(instance.state, { component: true, mixin: true });
+assert.deepEqual(
+  instance.state, { component: true, mixin: true },
+  'should inherit functionality of mixable methods'
+);
   >> ok
 ```
 __*`React.createClass` throws an Invariant Violation when duplicate `shouldComponentUpdate` or `render` methods exist, `react-stampit` will throw a TypeError.*__

--- a/src/stampit.js
+++ b/src/stampit.js
@@ -110,9 +110,8 @@ function extractStatics(targ, src) {
  * @param {...Function} stamp Two or more stamps.
  * @return {Function} A new stamp composed from arguments.
  */
-function compose(...factories) {
-  let stamps = factories.slice(),
-      result = stampit.init(),
+function compose(...stamps) {
+  let result = stampit(),
       refs = { state: {} },
       init = [], methods = {}, statics = {};
 
@@ -152,7 +151,7 @@ function compose(...factories) {
  * @return {Object} stamp.fixed An object map containing the fixed prototypes.
  */
 function rStampit(React, props) {
-  let stamp = React ? stampit.convertConstructor(React.Component) : stampit.init();
+  let stamp = React ? stampit.convertConstructor(React.Component) : stampit();
   let refs, methods, statics;
 
   // shortcut for converting React's class to a stamp

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import assign from 'lodash/object/assign';
+import merge from 'lodash/object/merge';
 import stampit from 'stampit';
 
 import { compose } from './stampit';
@@ -61,7 +62,7 @@ export function getEnum(target) {
  */
 export function stamp(Class) {
   const constructor = function() {
-    assign(this, new Class());
+    merge(this, new Class());
   };
   const methods = assign({},
     Object.getPrototypeOf(Class).prototype,

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -6,7 +6,7 @@ import stampit from '../src/stampit';
 import { stamp } from '../src/stampit';
 
 test('stamp decorator', (t) => {
-  t.plan(5);
+  t.plan(4);
 
   @stamp
   class Component extends React.Component {
@@ -18,27 +18,36 @@ test('stamp decorator', (t) => {
       };
     }
 
-    render() {}
+    render() {
+      return null;
+    }
   }
 
-  Component.propTypes = {
-    foo: '',
+  Component.defaultProps = {
+    foo: 'foo',
   };
 
   const mixin = {
-    propTypes: {
-      bar: '',
+    state: {
+      bar: 'bar',
+    },
+
+    defaultProps: {
+      bar: 'bar',
     },
   };
 
   t.ok(stampit.isStamp(Component), 'converts class to stamp');
   /* eslint-disable new-cap */
-  t.ok(Component().state.foo, 'maps state');
   t.ok(Component().render, 'maps methods');
-  t.ok(Component.propTypes, 'maps statics');
   t.deepEqual(
-    keys(Component.compose(mixin).propTypes), ['bar', 'foo'],
-    'brings composability'
+    keys(Component.compose(mixin)().state), ['bar', 'foo'],
+    'merges state'
   );
+  t.deepEqual(
+    keys(Component.compose(mixin).defaultProps), ['bar', 'foo'],
+    'merges statics'
+  );
+
   /* eslint-enable new-cap */
 });


### PR DESCRIPTION
Relates to issue #9.
- deep merge `this` inside `.init` closure when using class decorator
  
  Fixes scenario when a mixin is introducing state to a class that declared state in it's constructor
- use correct convenience property for stamp decorator test
- stampit() instead of wrongly used stampit.init()

cc @ericelliott 
