### PR TITLE
API refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ or by [downloading the latest release](https://github.com/stampit-org/react-stam
 
 This library is the result of wondering about what other ways a React component could be represented. [Stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) are a cool concept, and more importantly have proven to be a great alternative to `React.createClass` and the ES6 `class` due to their flexibility and use of multiple kinds of prototypal inheritance.
 
-react-stampit has an API similar to `React.createClass`. The factory accepts two parameters, the first being the React library and the second being an object comprised of React component properties.
+react-stampit has an API similar to `React.createClass` in that it takes an object comprised of React properties as a parameter. But that is really where the similarities end. react-stampit is a factory that returns a component producing factory. The returned factory takes the React library as a parameter. By using dependency injection for the React library, we are able to avoid problems caused by multiple instances of React. Read more about that [here](https://medium.com/@dan_abramov/two-weird-tricks-that-fix-react-7cf9bbdef375).
 
 ```js
-const component = stampit(React, {
+const componentFactory = stampit({
   state: {},
   statics: {},
 
@@ -35,24 +35,38 @@ const component = stampit(React, {
 
   // ...methods
 });
+
+const component = componentFactory(React);
 ```
 
-The best part about [stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) is their composability. What this means is that `n` number of stamps can be combined into a new stamp which inherits each passed stamp's behavior. This is perfect for React, since `class` is being pushed as the new norm and does not provide an idiomatic way to use mixins. (classical inheritance :disappointed:). While stamp composability on the surface is not idiomatic, the conventions used underneath are; it is these conventions that provide a limitless way to extend any React component.
+The best part about [stamps](https://en.wikipedia.org/wiki/Stamp_%28object-oriented_programming%29) is their composability. What this means is that `n` number of stamps can be combined into a new stamp which inherits each passed stamp's behavior. This is perfect for React, since `class` is being pushed as the new norm and does not provide an idiomatic way to use mixins (classical inheritance :disappointed:). While stamp composability on the surface is not idiomatic, the conventions used underneath are; it is these conventions that provide a limitless way to extend any React component.
+
+__mixin1.jsx__
 
 ```js
-const mixin1 = {
+export default {
   componentWillMount() {
     this.state.mixin1 = true;
   },
 };
+```
 
-const mixin2 = {
+__mixin2.jsx__
+
+```js
+export default {
   componentWillMount() {
     this.state.mixin2 = true;
   },
 };
+```
 
-const Component = stampit(React, {
+__component.jsx__
+
+```js
+import stampit from 'react-stampit';
+
+export default stampit({
   state: {
     comp: false,
     mixin1: false,
@@ -70,7 +84,23 @@ const Component = stampit(React, {
   render() {
     return <input type='button' onClick={() => this._onClick()} />;
   },
-}).compose(mixin1, mixin2);
+});
+```
+
+__app.jsx__
+
+```js
+import React from 'react';
+
+import componentFactory from './component';
+import mixin1 from './mixin1';
+import mixin2 from './mixin2';
+
+const Component = componentFactory(React).compose(mixin1, mixin2);
+
+/**
+ * Do things
+ */
 ```
 
 ```js
@@ -96,9 +126,9 @@ You may have noticed a few interesting behaviors.
 
  This is shorthand syntax for:
  ```js
- stampit(null, {
+ stampit({
    // stuff
- });
+ })();
  ```
 
 If you feel limited by `class`, or want a fresh take on `React.createClass`, maybe give react-stampit a try and learn more about what [stampit](https://github.com/stampit-org/stampit) is all about. And please report any issues you encounter!
@@ -109,13 +139,19 @@ For some advanced use cases, see [here](docs/advanced.md).
 
 ## API
 
-### stampit(React [,properties])
+### stampit([props])
 
-Return a factory function (called a stamp) that will produce new React components using the prototypes that are passed in or composed.
+Return a factory function that will produce a stamp factory.
+
+* `@param {Object} [props]` A map of property names and values specialized for React.
+* `@return {Function} stampFactory` A factory to produce stamps.
+
+### stampFactory(React)
+
+Return a stamp using the prototypes that were passed in or composed.
 
 * `@param {Object} React` The React library.
-* `@param {Object} [props]` A map of property names and values specialized for React.
-* `@return {Function} stamp` A factory to produce React components using the given properties.
+* `@return {Function} stamp` A factory to produce React components.
 * `@return {Object} stamp.fixed` An object map containing the fixed prototypes.
 * `@return {Function} stamp.compose` Add mixin (stamp) to stamp. Chainable.
 

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -12,7 +12,8 @@ const mixin = {
   },
 };
 
-const component = stampit(React).compose(mixin);
+const componentFactory = stampit();
+const component = componentFactory(React).compose(mixin);
 ```
 
 ```js
@@ -41,7 +42,7 @@ const mixin = {
   },
 };
 
-const component = stampit(React, {
+const componentFactory = stampit({
   statics: {
     someStatic: {
       foo: 'foo',
@@ -51,7 +52,8 @@ const component = stampit(React, {
   propTypes: {
     foo: React.PropTypes.string,
   },
-}).compose(mixin);
+});
+const component = componentFactory(React).compose(mixin);
 ```
 
 ```js
@@ -99,7 +101,7 @@ const mixin = {
   },
 };
 
-const component = stampit(React, {
+const componentFactory = stampit({
   state: {
     component: false,
     mixin: false,
@@ -108,7 +110,8 @@ const component = stampit(React, {
   componentDidMount() {
     this.state.component = true;
   }
-}).compose(mixin);
+});
+const component = componentFactory(React).compose(mixin);
 
 const instance = component();
 instance.componentDidMount();

--- a/test/basics.js
+++ b/test/basics.js
@@ -5,19 +5,11 @@ import stampit from '../src/stampit';
 
 const TestUtils = React.addons.TestUtils;
 
-test('stampit()', (t) => {
+test('stampit()()', (t) => {
   t.plan(1);
 
-  t.ok(
-    stampit.isStamp(stampit()),
-    'should return a stamp'
-  );
-});
-
-test('stampit(React, props)', (t) => {
-  t.plan(1);
-
-  const stamp = stampit(React, {});
+  const stampFactory = stampit();
+  const stamp = stampFactory();
 
   t.ok(
     stampit.isStamp(stamp),
@@ -25,10 +17,11 @@ test('stampit(React, props)', (t) => {
   );
 });
 
-test('stampit(React)', (t) => {
+test('stampit(props)(React)', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React);
+  const stampFactory = stampit({});
+  const stamp = stampFactory(React);
 
   t.ok(
     stampit.isStamp(stamp),
@@ -36,10 +29,11 @@ test('stampit(React)', (t) => {
   );
 });
 
-test('stampit(null, props)', (t) => {
+test('stampit()(React)', (t) => {
   t.plan(1);
 
-  const stamp = stampit(null, {});
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
 
   t.ok(
     stampit.isStamp(stamp),
@@ -47,12 +41,25 @@ test('stampit(null, props)', (t) => {
   );
 });
 
-test('stampit(React, { render() })()', (t) => {
+test('stampit(props)()', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React, {
+  const stampFactory = stampit({});
+  const stamp = stampFactory();
+
+  t.ok(
+    stampit.isStamp(stamp),
+    'should return a stamp'
+  );
+});
+
+test('stampit({ render() })()()', (t) => {
+  t.plan(1);
+
+  const stampFactory = stampit({
     render() {},
   });
+  const stamp = stampFactory(React);
 
   t.ok(
     TestUtils.isCompositeComponent(stamp()),
@@ -60,11 +67,14 @@ test('stampit(React, { render() })()', (t) => {
   );
 });
 
-test('stampit(React, props).compose', (t) => {
+test('stampit(props)(React).compose', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).compose, 'function',
+    typeof stamp.compose, 'function',
     'should be a function'
   );
 });
@@ -78,74 +88,98 @@ test('stampit.compose', (t) => {
   );
 });
 
-test('stampit(React, props).create', (t) => {
+test('stampit(props)(React).create', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).create, 'undefined',
+    typeof stamp.create, 'undefined',
     'should be undefined'
   );
 });
 
-test('stampit(React, props).init', (t) => {
+test('stampit(props)(React).init', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).init, 'undefined',
+    typeof stamp.init, 'undefined',
     'should be undefined'
   );
 });
 
-test('stampit(React, props).methods', (t) => {
+test('stampit(props)(React).methods', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).methods, 'undefined',
+    typeof stamp.methods, 'undefined',
     'should be undefined'
   );
 });
 
-test('stampit(React, props).state', (t) => {
+test('stampit(props)(React).state', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).state, 'undefined',
+    typeof stamp.state, 'undefined',
     'should be undefined'
   );
 });
 
-test('stampit(React, props).refs', (t) => {
+test('stampit(props)(React).refs', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).refs, 'undefined',
+    typeof stamp.refs, 'undefined',
     'should be undefined'
   );
 });
 
-test('stampit(React, props).props', (t) => {
+test('stampit(props)(React).props', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).props, 'undefined',
+    typeof stamp.props, 'undefined',
     'should be undefined'
   );
 });
 
-test('stampit(React, props).enclose', (t) => {
+test('stampit(props)(React).enclose', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).enclose, 'undefined',
+    typeof stamp.enclose, 'undefined',
     'should be undefined'
   );
 });
 
-test('stampit(React, props).static', (t) => {
+test('stampit(props)(React).static', (t) => {
   t.plan(1);
 
+  const stampFactory = stampit();
+  const stamp = stampFactory(React);
+
   t.equal(
-    typeof stampit(React).static, 'undefined',
+    typeof stamp.static, 'undefined',
     'should be undefined'
   );
 });

--- a/test/methods.js
+++ b/test/methods.js
@@ -3,12 +3,13 @@ import test from 'tape';
 
 import stampit from '../src/stampit';
 
-test('stampit(React, { method() {} })()', (t) => {
+test('stampit({ method() {} })(React)()', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React, {
+  const stampFactory = stampit({
     render() {},
   });
+  const stamp = stampFactory(React);
 
   t.equal(
     typeof Object.getPrototypeOf(stamp()).render, 'function',

--- a/test/state.js
+++ b/test/state.js
@@ -4,14 +4,15 @@ import test from 'tape';
 
 import stampit from '../src/stampit';
 
-test('stampit(React, { state: obj })()', (t) => {
+test('stampit({ state: obj })(React)()', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React, {
+  const stampFactory = stampit({
     state: {
       foo: '',
     },
   });
+  const stamp = stampFactory(React);
 
   t.ok(
     has(stamp().state, 'foo'),

--- a/test/statics.js
+++ b/test/statics.js
@@ -4,14 +4,15 @@ import test from 'tape';
 
 import stampit from '../src/stampit';
 
-test('stampit(React, { statics: obj })', (t) => {
+test('stampit({ statics: obj })(React)', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React, {
+  const stampFactory = stampit({
     statics: {
       foo: '',
     },
   });
+  const stamp = stampFactory(React);
 
   t.ok(
     has(stamp, 'foo'),
@@ -19,12 +20,13 @@ test('stampit(React, { statics: obj })', (t) => {
   );
 });
 
-test('stampit(React, { contextTypes: obj })', (t) => {
+test('stampit({ contextTypes: obj })(React)', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React, {
+  const stampFactory = stampit({
     contextTypes: {},
   });
+  const stamp = stampFactory(React);
 
   t.ok(
     has(stamp, 'contextTypes'),
@@ -32,12 +34,13 @@ test('stampit(React, { contextTypes: obj })', (t) => {
   );
 });
 
-test('stampit(React, { childContextTypes: obj })', (t) => {
+test('stampit({ childContextTypes: obj })(React)', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React, {
+  const stampFactory = stampit({
     childContextTypes: {},
   });
+  const stamp = stampFactory(React);
 
   t.ok(
     has(stamp, 'childContextTypes'),
@@ -45,12 +48,13 @@ test('stampit(React, { childContextTypes: obj })', (t) => {
   );
 });
 
-test('stampit(React, { propTypes: obj })', (t) => {
+test('stampit({ propTypes: obj })(React)', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React, {
+  const stampFactory = stampit({
     propTypes: {},
   });
+  const stamp = stampFactory(React);
 
   t.ok(
     has(stamp, 'propTypes'),
@@ -58,12 +62,13 @@ test('stampit(React, { propTypes: obj })', (t) => {
   );
 });
 
-test('stampit(React, { defaultProps: obj })', (t) => {
+test('stampit({ defaultProps: obj })(React)', (t) => {
   t.plan(1);
 
-  const stamp = stampit(React, {
+  const stampFactory = stampit({
     defaultProps: {},
   });
+  const stamp = stampFactory(React);
 
   t.ok(
     has(stamp, 'defaultProps'),


### PR DESCRIPTION
Fixes issue #13 

**Old API**

``` js
const component = stampit(React, {
  state: {},
  statics: {},

  // convenience props for React statics
  contextTypes: {},
  childContextTypes: {}.
  propTypes: {},
  defaultProps: {},

  // ...methods
});
```

**New API**

``` js
const componentFactory = stampit({
  state: {},
  statics: {},

  // convenience props for React statics
  contextTypes: {},
  childContextTypes: {}.
  propTypes: {},
  defaultProps: {},

  // ...methods
});

const component = componentFactory(React);
```

Tests are green, docs have been updated. The only thing left is to check that the newly updated doc examples are syntactically correct.

cc @ericelliott 
