### PR TITLE
Memoize stamps using 'displayName' prop as a toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ __component.jsx__
 import stampit from 'react-stampit';
 
 export default React => stampit(React, {
+  displayName: 'Component',
+
   state: {
     comp: false,
     mixin1: false,

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -48,6 +48,32 @@ test('stamp decorator', (t) => {
     keys(Component.compose(mixin).defaultProps), ['bar', 'foo'],
     'merges statics'
   );
-
   /* eslint-enable new-cap */
+});
+
+test('stamp factory', (t) => {
+  t.plan(2);
+
+  const stampFactory1 = React => stampit(React, {
+    displayName: 'Component',
+  });
+
+  const stampFactory2 = React => stampit(React, {
+    displayName: 'ReactStamp',
+  });
+
+  const stamp1 = stampFactory1(React);
+  const stamp2 = stampFactory1(React);
+  const stamp3 = stampFactory2(React);
+  const stamp4 = stampFactory2(React);
+
+  t.equal(
+    stamp1, stamp2,
+    'memoizes stamp when displayName prop !== \'ReactStamp\''
+  );
+
+  t.notEqual(
+    stamp3, stamp4,
+    'does not memoize stamp when displayName prop == \'ReactStamp\''
+  );
 });

--- a/test/statics.js
+++ b/test/statics.js
@@ -19,6 +19,19 @@ test('stampit(React, { statics: obj })', (t) => {
   );
 });
 
+test('stampit(React, { displayName: str })', (t) => {
+  t.plan(1);
+
+  const stamp = stampit(React, {
+    displayName: 'stamp',
+  });
+
+  t.ok(
+    has(stamp, 'displayName'),
+    'should return a stamp with `displayName` prop'
+  );
+});
+
 test('stampit(React, { contextTypes: obj })', (t) => {
   t.plan(1);
 


### PR DESCRIPTION
Quick draft of stamp memoization.

cc @ericelliott 
