### PR TITLE
Support memoization in composition

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
     "brace-style": 2,
     "comma-dangle": [2, "always-multiline"],
     "consistent-return": 2,
-    "curly": 2,
+    "curly": [2, "multi-line"],
     "dot-notation": 2,
     "eol-last": 2,
     "indent": [2, 2],

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,19 @@
+let cache = {};
+
+export function isStampCached(identifier) {
+  return identifier && cache.hasOwnProperty(identifier);
+}
+
+export function cacheStamp(stamp) {
+  const displayName = stamp.displayName;
+
+  if (displayName && displayName !== 'ReactStamp') {
+    cache[displayName] = stamp;
+  }
+
+  return stamp;
+}
+
+export function getCachedStamp(identifier) {
+  return cache[identifier];
+}

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -52,7 +52,7 @@ test('stamp decorator', (t) => {
 });
 
 test('stamp factory', (t) => {
-  t.plan(2);
+  t.plan(4);
 
   const stampFactory1 = React => stampit(React, {
     displayName: 'Component',
@@ -66,14 +66,28 @@ test('stamp factory', (t) => {
   const stamp2 = stampFactory1(React);
   const stamp3 = stampFactory2(React);
   const stamp4 = stampFactory2(React);
+  const composedStamp1 = stampit.compose(stamp1, { displayName: 'ComposedStamp1' });
+  const composedStamp2 = stampit.compose(stamp1, { displayName: 'ComposedStamp1' });
+  const composedStamp3 = stampit.compose(stamp1, { displayName: 'ReactStamp' });
+  const composedStamp4 = stampit.compose(stamp1, { displayName: 'ReactStamp' });
 
   t.equal(
     stamp1, stamp2,
-    'memoizes stamp when displayName prop !== \'ReactStamp\''
+    'is memoized when displayName prop !== \'ReactStamp\''
   );
 
   t.notEqual(
     stamp3, stamp4,
-    'does not memoize stamp when displayName prop == \'ReactStamp\''
+    'is not memoized when displayName prop == \'ReactStamp\''
+  );
+
+  t.equal(
+    composedStamp1, composedStamp2,
+    'is memoized in composition when displayName prop !== \'ReactStamp\''
+  );
+
+  t.notEqual(
+    composedStamp3, composedStamp4,
+    'is not memoized in composition when displayName prop == \'ReactStamp\''
   );
 });


### PR DESCRIPTION
Overlooked this use case earlier. If a component gets composed with mixins, the resultant component should get cached. This works by using the last found displayName prop in the composition chain as the key for caching the component.

I may be missing some edge cases in this PR, I still need to think a bit more on it.
