### PR TITLE
Add initializers prop to description object

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ react-stampit has an API similar to `React.createClass`. The factory accepts two
 
 ```js
 stampit(React, {
+  init: [],
   state: {},
   statics: {},
 

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ function compose(...stamps) {
  */
 function rStampit(React, props) {
   let stamp = React ? stampit.convertConstructor(React.Component) : stampit();
-  let refs, methods, statics;
+  let refs, init, methods, statics;
 
   // Shortcut for converting React's class to a stamp.
   if (isEmpty(props)) {
@@ -158,15 +158,17 @@ function rStampit(React, props) {
     return stripStamp(stamp);
   }
 
+  init = props.init || [];
+  refs = props.state && { state: props.state } || {};
   statics = assign({},
     props.statics,
     pick(props, ['contextTypes', 'childContextTypes', 'propTypes', 'defaultProps']),
     { displayName: props.displayName || 'ReactStamp' }
   );
-  methods = omit(props, (val, key) => has(statics, key) || ['state', 'statics'].indexOf(key) >= 0);
-  refs = props.state && { state: props.state };
+  methods = omit(props, (val, key) => has(statics, key) || ['init', 'state', 'statics'].indexOf(key) >= 0);
 
   stamp = stamp
+    .init(init)
     .refs(refs)
     .methods(methods)
     .static(statics);

--- a/test/state.js
+++ b/test/state.js
@@ -18,3 +18,18 @@ test('stampit(React, { state: obj })()', (t) => {
     'should return an instance with `state` prop'
   );
 });
+
+test('stampit(React, { init() { ... } })()', (t) => {
+  t.plan(1);
+
+  const stamp = stampit(React, {
+    init() {
+      this.state = { foo: '' };
+    },
+  });
+
+  t.ok(
+    has(stamp().state, 'foo'),
+    'should return an instance with `state` prop'
+  );
+});


### PR DESCRIPTION
Issue #31 

@ericelliott 

> Why not add .compose() and initializers seeing as how we need to get moving toward the open Stamp specification anyway?

`.compose` is already present. We do need to to make a `compose` util though.
